### PR TITLE
Add cmake support for hipSYCL, fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,7 @@ project (SYCLAcademy)
 option(SYCL_ACADEMY_USE_COMPUTECPP "Configure to compile with ComputeCpp" OFF)
 option(SYCL_ACADEMY_USE_DPCPP "Configure to compile with DPC++" OFF)
 option(SYCL_ACADEMY_USE_HIPSYCL "Configure to compile with hipSYCL" OFF)
-option(SYCL_ACADEMY_INSTALL_ROOT "Path to the root directory of the chosen "
-  "SYCL implementation" "NOT-FOUND")
+option(SYCL_ACADEMY_INSTALL_ROOT "Path to the root directory of the chosen SYCL implementation" "NOT-FOUND")
 
 set(SYCL_IMPLEMENTATIONS_USED 0)
 if(SYCL_ACADEMY_USE_COMPUTECPP)
@@ -72,13 +71,13 @@ endif()
 # hipSYCL setup
 
 if (SYCL_ACADEMY_USE_HIPSYCL)
-  # TODO(Gordon)
+  find_package(hipSYCL CONFIG REQUIRED PATHS ${SYCL_ACADEMY_INSTALL_ROOT}/lib/cmake)
 endif()
 
 # Exercises
 
 enable_testing()
-add_subdirectory(External/Catch2)
+add_subdirectory(External/catch2)
 
 add_subdirectory(Code_Exercises)
 

--- a/Code_Exercises/CMakeLists.txt
+++ b/Code_Exercises/CMakeLists.txt
@@ -30,8 +30,23 @@ function(add_sycl_executable_dpcpp prefix source)
   #TODO
 endfunction()
 
+# Note: This is copy-pasted from the ComputeCpp function,
+# we may want to refactor this into a single function.
 function(add_sycl_executable_hipsycl prefix source)
-  #TODO
+  add_executable("${prefix}_${source}" "${source}.cpp")
+  target_include_directories("${prefix}_${source}" PRIVATE
+    ${PROJECT_SOURCE_DIR}/Utilities/include ${PROJECT_SOURCE_DIR}/External/stb)
+  target_link_libraries("${prefix}_${source}" PRIVATE Threads::Threads)
+  target_link_libraries("${prefix}_${source}" PUBLIC Catch2::Catch2)
+  set_target_properties("${prefix}_${source}" PROPERTIES CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)
+
+  add_sycl_to_target(
+    TARGET "${prefix}_${source}"
+    SOURCES "${source}.cpp"
+  )
+    
+  add_test(${source} ${source})
 endfunction()
 
 function(add_sycl_executable prefix source)
@@ -40,7 +55,7 @@ function(add_sycl_executable prefix source)
   elseif(SYCL_ACADEMY_USE_DPCPP)
     add_sycl_executable_dpcpp(prefix source)
   elseif(SYCL_ACADEMY_USE_HIPSYCL)
-    add_sycl_executable_hipsycl(prefix source)
+    add_sycl_executable_hipsycl(${prefix} ${source})
   endif()
 endfunction()
 
@@ -49,4 +64,4 @@ add_subdirectory(Exercise_2_Configuring_a_Queue)
 add_subdirectory(Exercise_3_Hello_World)
 add_subdirectory(Exercise_4_Vector_Add)
 add_subdirectory(Exercise_5_Image_Grayscale)
-add_subdirectory(Exercise_6_matrix_Transpose)
+add_subdirectory(Exercise_6_Matrix_Transpose)


### PR DESCRIPTION
This adds initial support for hipSYCL in the cmake infrastructure. Note that the implementation of the `add_sycl_executable_hipsycl` function is exactly the same as the ComputeCpp one, so this could probably be unified into a single one if desired.

This also fixes some typos, (mostly related to capitalization) which I assume should help all implementations. I guess this was only tested on Windows and not on case-sensitive operating systems ;)

Currently, hipSYCL compilation already aborts at the hello world exercise because we don't have the `stream` class yet in hipSYCL because it never seemed that important to me. I can push a hot fix implementation to hipSYCL, but this would not fix the issue for users who are not on master (and e.g. use our precompiled packages). I wonder if it would be better to work around such issues using `#ifdefs` in the code? `printf` works on hipSYCL.