### PR TITLE
Align id<> dimension with range<> dimension in parallel for

### DIFF
--- a/Code_Exercises/Exercise_5_Image_Grayscale/solution.cpp
+++ b/Code_Exercises/Exercise_5_Image_Grayscale/solution.cpp
@@ -136,7 +136,7 @@ TEST_CASE("coalesced", "sycl_04_grayscale") {
               cgh);
 
           cgh.parallel_for<coalesced>(
-            cl::sycl::range<2>(width, height), [=](cl::sycl::id<1> idx) {
+            cl::sycl::range<2>(width, height), [=](cl::sycl::id<2> idx) {
               auto linearId =
                 (idx[0] * height * channels) + (idx[1] * channels);
 

--- a/Code_Exercises/Exercise_6_Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Exercise_6_Matrix_Transpose/solution.cpp
@@ -90,7 +90,7 @@ TEST_CASE("naive", "sycl_05_transpose") {
 
             cgh.parallel_for<naive>(
                 cl::sycl::range<2>(inputMat.width(), inputMat.height()),
-                [=](cl::sycl::id<1> idx) {
+                [=](cl::sycl::id<2> idx) {
                   auto rowMajorId = (idx[1] * inputMat.width()) + idx[0];
                   auto columnMajorId = (idx[0] * inputMat.height()) + idx[1];
 


### PR DESCRIPTION
This fixes two cases in the solutions where the `id<>` dimension in the kernel did not match the dimensionality of the iteration range, which is illegal in SYCL as far as I know.