### PR TITLE
Use myQueue.wait() at the end of exercise 1

### DIFF
--- a/Code_Exercises/Exercise_1_Getting_Started/hello_world.cpp
+++ b/Code_Exercises/Exercise_1_Getting_Started/hello_world.cpp
@@ -56,5 +56,8 @@ int main() {
     });
   });
 
+  /* Make sure that the queue has finished all work before terminating. */
+  myQueue.wait();
+  
   return 0;
 }


### PR DESCRIPTION
In exercise 1, the code just uses stream to print "hello world" and then exits. According to my understanding in SYCL 1.2.1 there is no implicit wait in the queue destructor. This would make this code illegal since there is no synchronization point in the code (such as e.g. a buffer writeback or host accessor) before the program ends.

This PR solves this issue by adding an explicit `wait()`.