### PR TITLE
Don't capture entire matrix by value in exercise 6

### DIFF
--- a/Code_Exercises/Exercise_6_Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Exercise_6_Matrix_Transpose/solution.cpp
@@ -88,11 +88,14 @@ TEST_CASE("naive", "sycl_05_transpose") {
                 outputMatBuf.template get_access<cl::sycl::access::mode::write>(
                     cgh);
 
+            const auto width = inputMat.width();
+            const auto height = inputMat.height();
+                
             cgh.parallel_for<naive>(
-                cl::sycl::range<2>(inputMat.width(), inputMat.height()),
+                cl::sycl::range<2>(width, height),
                 [=](cl::sycl::id<1> idx) {
-                  auto rowMajorId = (idx[1] * inputMat.width()) + idx[0];
-                  auto columnMajorId = (idx[0] * inputMat.height()) + idx[1];
+                  auto rowMajorId = (idx[1] * width) + idx[0];
+                  auto columnMajorId = (idx[0] * height) + idx[1];
 
                   outputMatAcc[rowMajorId] = inputMatAcc[columnMajorId];
                 });


### PR DESCRIPTION
I think this here is actually an interesting one: In the naive implementation, the current code calls `inputMat.width()` and `inputMat.height()` inside the kernel. This causes `inputMat` to be captured by value by the kernel lambda. This in turn means that the entire content of the matrix is used as *kernel argument* (also in principle rendering `inputMatBuf` pointless). 
As it turns out, on hipSYCL CUDA, this massive size of the kernel argument causes the CUDA kernel argument buffer to explode during `ptxas` execution.

The problem is solved by simply storing width/height in constants which can then be efficiently captured and used inside the kernel.